### PR TITLE
Systemd Fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV container docker
 ENV TERM linux
 
 RUN dnf update -y; \
-dnf install 'dnf-command(copr)' sudo dnsmasq dos2unix iproute procps-ng -y; \
+dnf install 'dnf-command(copr)' sudo bc dnsmasq dos2unix iproute procps-ng -y; \
 dnf copr enable jdoss/caddy -y; \
 dnf install caddy -y; \
 dnf clean all; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,20 @@
-FROM jdoss/fedora-systemd
+FROM fedora
 MAINTAINER Joe Doss <joe@joedoss.com>
 ENV container docker
 ENV TERM linux
 
-RUN dnf update -y; \
+RUN dnf -y update; \
+systemctl mask 
+dev-hugepages.mount \
+dev-mqueue.mount \
+display-manager.service \
+graphical.target \
+sys-fs-fuse-connections.mount \
+sys-kernel-config.mount \
+sys-kernel-debug.mount \
+systemd-logind.service \
+systemd-remount-fs.service \
+tmp.mount; \
 dnf install 'dnf-command(copr)' sudo bc dnsmasq dos2unix iproute procps-ng -y; \
 dnf copr enable jdoss/caddy -y; \
 dnf install caddy -y; \
@@ -40,5 +51,9 @@ systemctl enable dnsmasq
 EXPOSE 53/tcp
 EXPOSE 53/udp
 EXPOSE 80/tcp
+
+VOLUME ["/home/dockerhole/data"]
+VOLUME ["/sys/fs/cgroup"]
+VOLUME ["/run"]
 
 CMD ["/usr/lib/systemd/systemd"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV container docker
 ENV TERM linux
 
 RUN dnf -y update; \
-systemctl mask 
+systemctl mask \
 dev-hugepages.mount \
 dev-mqueue.mount \
 display-manager.service \

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -37,7 +37,8 @@ http://dockerhole {
   header / X-Docker-Hole "Dockerhole"
 
   rewrite {
-    /hole/index.html
+    r  (.*)
+    to /hole/index.html
   }
 
   errors {

--- a/dockerhole.service
+++ b/dockerhole.service
@@ -5,8 +5,8 @@ After=docker.service
 
 [Service]
 Restart=always
-ExecStart=/usr/bin/docker start -a dockerhole
-ExecStop=/usr/bin/docker stop -t 2 dockerhole
+ExecStart=/usr/bin/docker run --privileged --restart=always --name dockerhole -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro dockerhole /usr/lib/systemd/systemd
+ExecStop=/usr/bin/docker stop -t 2 dockerhole; /usr/bin/docker rm -f dockerhole
 
 [Install]
 WantedBy=local.target

--- a/install_dockerhole
+++ b/install_dockerhole
@@ -2,7 +2,7 @@
 
 sudo docker build -t dockerhole -f Dockerfile .
 
-sudo docker run --name dockerhole -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro dockerhole /usr/lib/systemd/systemd
+sudo docker run --privileged --restart=always --name dockerhole -d -v /sys/fs/cgroup:/sys/fs/cgroup:ro dockerhole /usr/lib/systemd/systemd
 
 sudo cp dockerhole.service /etc/systemd/system
 sudo systemctl daemon-reload


### PR DESCRIPTION
Seems some changes in systemd-222 no longer allow for running systemd in a container without the `--privileged` flag. This PR fixes that issue and a few other bugs.
